### PR TITLE
Use bash instead of sh for boot script

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
Because we use statement like this "${COOKIE_MODE:0:1}"
