### PR TITLE
Add runnig_conf to init arguments

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -186,6 +186,7 @@ generate_sys_config() {
     if [ -f "$__schema_file" ]; then
         if [ -f "$__conform_file" ]; then
             __running_conf="$GENERATED_CONFIG_DIR/$REL_NAME.conf"
+            CONFORM_OPTS="-conform_schema ${__schema_file} -conform_config ${__conform_file} -running_conf ${__running_conf}"
 
             # always copy release-config to running-config
             echo "copying $__conform_file to $__running_conf ..."
@@ -199,7 +200,6 @@ generate_sys_config() {
                 __conform="$ROOTDIR/bin/conform"
             fi
 
-            CONFORM_OPTS="-conform_schema ${__schema_file} -conform_config ${__conform_file}"
             result="$("$BINDIR/escript" "$__conform" --conf "$__conform_file" --schema "$__schema_file" --config "$RELEASE_CONFIG_DIR/sys.config" --output-dir "$GENERATED_CONFIG_DIR")"
             exit_status="$?"
             if [ "$exit_status" -ne 0 ]; then


### PR DESCRIPTION
Because we want to copy .conf file to running_conf 
